### PR TITLE
Applying fixes on gatherSources from zos

### DIFF
--- a/packages/fs/src/index.ts
+++ b/packages/fs/src/index.ts
@@ -1,4 +1,11 @@
-export { Context, firstResult, Options, ResolverEngine, SubParser, SubResolver } from "@openzeppelin/resolver-engine-core";
+export {
+  Context,
+  firstResult,
+  Options,
+  ResolverEngine,
+  SubParser,
+  SubResolver,
+} from "@openzeppelin/resolver-engine-core";
 import { parsers as coreParsers, resolvers as coreResolvers } from "@openzeppelin/resolver-engine-core";
 import { FsParser } from "./parsers/fsparser";
 import { BacktrackFsResolver } from "./resolvers/backtrackfsresolver";

--- a/packages/imports-fs/src/index.ts
+++ b/packages/imports-fs/src/index.ts
@@ -1,4 +1,11 @@
-export { Context, firstResult, Options, ResolverEngine, SubParser, SubResolver } from "@openzeppelin/resolver-engine-core";
+export {
+  Context,
+  firstResult,
+  Options,
+  ResolverEngine,
+  SubParser,
+  SubResolver,
+} from "@openzeppelin/resolver-engine-core";
 export {
   findImports,
   gatherSources,


### PR DESCRIPTION
This PR takes changes on gatherSources from the https://github.com/zeppelinos/zos repository and applies them on resolver-engine directly:

- Handle spaces in paths
- Handle imports like `import "contracts/folder/Contract.sol";`